### PR TITLE
Don't run Markdown on old reviews

### DIFF
--- a/www/allreviews
+++ b/www/allreviews
@@ -202,6 +202,7 @@ if ($errMsg) {
              null) as embargodate,
            reviews.special as special,
            date_format(greatest(reviews.createdate, ifnull(embargodate, cast(0 as datetime))), '%M %e, %Y') as publicationdatefmt,
+           reviews.moddate as moddate,
            date_format(greatest(reviews.moddate, ifnull(embargodate, cast(0 as datetime))), '%M %e, %Y') as moddatefmt,
            sum(reviewvotes.vote = 'Y' and ifnull(rvu.sandbox, 0) in $sandbox) as helpful,
            sum(reviewvotes.vote = 'N' and ifnull(rvu.sandbox, 0) in $sandbox) as unhelpful,

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -61,7 +61,7 @@ function getReviewQuery($db, $where)
     // as formatted for display, also to faciliate sorting.
     return
         "select sql_calc_found_rows
-           reviews.id as reviewid, rating, summary, review,
+           reviews.id as reviewid, rating, summary, review, moddate,
            date_format(greatest(reviews.moddate, ifnull(embargodate, cast(0 as datetime))), '%M %e, %Y') as moddatefmt,
            greatest(reviews.createdate, ifnull(embargodate, cast(0 as datetime))) as publicationdate,
            date_format(greatest(reviews.createdate, ifnull(embargodate, cast(0 as datetime))), '%M %e, %Y') as publicationdatefmt,
@@ -270,16 +270,20 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
     $qreviewid = mysql_real_escape_string($reviewid, $db);
     $rating = $rec['rating'];
     $summary = htmlspecialcharx($rec['summary']);
-    $review = fixDesc(parsedownMultilineText($rec['review']), FixDescSpoiler | FixDescMarkdown);
+    if (strcmp($rec['moddate'], '2025-08-26') < 0) {
+        $review = fixDesc($rec['review'], FixDescSpoiler);
+    } else {
+        $review = fixDesc(parsedownMultilineText($rec['review']), FixDescSpoiler | FixDescMarkdown);
+    }
     $publicationdate = $rec['publicationdatefmt'];
-    $moddate = $rec['moddatefmt'];
+    $moddatefmt = $rec['moddatefmt'];
     $lastupdateFootnote = null;
-    if ($moddate && $publicationdate != $moddate) {
+    if ($moddatefmt && $publicationdate != $moddatefmt) {
         // Rating-only review
         if ($review == "") {
-            $publicationdate .= " (last edited on $moddate)";
+            $publicationdate .= " (last edited on $moddatefmt)";
         } else {
-            $lastupdateFootnote = "This review was last edited on $moddate";
+            $lastupdateFootnote = "This review was last edited on $moddatefmt";
             $publicationdate .= "<span title=\"$lastupdateFootnote\">*</span>";
         }
     }

--- a/www/viewgame
+++ b/www/viewgame
@@ -1575,8 +1575,8 @@ if ($embargoCnt > 0)
         // show other (non-editorial) special reviews
         $result = mysql_query(
             "select reviews.id as reviewid,
-               rating, summary, review,
-               date_format(moddate, '%M %e, %Y') as moddate,
+               rating, summary, review, moddate,
+               date_format(moddate, '%M %e, %Y') as moddatefmt,
                specialreviewers.id as special,
                specialreviewers.name as specialname,
                users.id as userid, users.name as username, location


### PR DESCRIPTION
@pieartsy

Stacking a PR on top of https://github.com/pieartsy/ifdb/pull/7

This PR checks the `moddate` of the review; if the review was modified before today, then the review will not have Markdown applied. If someone edits the review, it will have Markdown applied.

(I think that'll be OK, because 90%+ of the time, editing and saving a review unmodified won't actually change its content, and most of the time when it _does_ change the content, it improves it.)

I'll need to update this date to the date at which we actually deploy this PR on the production website.

This should allow us to avoid writing code to add hundreds of reviews to https://github.com/pieartsy/ifdb/pull/6